### PR TITLE
Fix Entrypoint

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,8 +25,8 @@ jobs:
           images: |
             quay.io/costoolkit/upgradechannel-discovery
           tags: |
-            type=semver,pattern=v{{version}}
-            type=sha,format=short,prefix=${{ steps.export_tag.outputs.tag }}-
+            type=semver,pattern=v{{version}}, event=tag
+            type=sha,format=short,prefix=${{ steps.export_tag.outputs.tag }}-,event=branch
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ COPY --from=build /tmp /tmp
 # So https works
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /usr/bin/upgradechannel-discovery /usr/bin/upgradechannel-discovery
-ENTRYPOINT "/usr/bin/upgradechannel-discovery"
+ENTRYPOINT ["/usr/bin/upgradechannel-discovery"]


### PR DESCRIPTION
If no `[ ]` are added to the entrypoint, docker assumes that what you want is to call `/bin/sh -c ENTRYPOINT` which results on a failure as there is no sh in the image, its only the plugin.

This fixes it so the entrypoint is called properly to the binary directly bypassing the call to sh